### PR TITLE
config.json Unexpected String

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -19,7 +19,7 @@
 	
 	"nbeginnerRating":856,
 	"nexperiencedRating":1070,
-	"nadvancedRating":1324
+	"nadvancedRating":1324,
 	"beginnerRating":1400,
 	"experiencedRating":1600,
 	"advancedRating":1800


### PR DESCRIPTION
invalid syntax needs comma after "nadvancedRating":1324
